### PR TITLE
use MyPlot\WandChest hat gefehlt

### DIFF
--- a/src/MyPlot/subcommand/WandSubCommand.php
+++ b/src/MyPlot/subcommand/WandSubCommand.php
@@ -4,6 +4,7 @@ namespace MyPlot\subcommand;
 
 use MyPlot\MyPlot;
 use MyPlot\RandChest;
+use MyPlot\WandChest
 use pocketmine\command\CommandSender;
 use pocketmine\command\PluginCommand;
 use pocketmine\Player;


### PR DESCRIPTION
Internal server error wegen Fehlende WandChest Datei in WandSubCommand